### PR TITLE
fix: Rely on the image_original_user image metadata property

### DIFF
--- a/group_vars/debian
+++ b/group_vars/debian
@@ -1,2 +1,0 @@
----
-ansible_user: debian

--- a/group_vars/rocky
+++ b/group_vars/rocky
@@ -1,2 +1,0 @@
----
-ansible_user: cloud-user

--- a/group_vars/ubuntu
+++ b/group_vars/ubuntu
@@ -1,2 +1,0 @@
----
-ansible_user: ubuntu

--- a/openstack.yml
+++ b/openstack.yml
@@ -4,6 +4,7 @@ fail_on_errors: yes
 only_clouds: []
 legacy_groups: false
 compose:
+  'ansible_user': 'openstack.volumes[0].volume_image_metadata.image_original_user'
   'os_distro': 'openstack.volumes[0].volume_image_metadata.os_distro'
 keyed_groups:
   - prefix: ''


### PR DESCRIPTION
Rather than discerning the default image user from the operating system distribution, we can interrogate the `image_original_user` property to suss out which SSH user we should be connecting as.

Thus, discover the proper value for `ansible_user` from that image property, rather than setting it from a `group_vars` file.

Reference:
https://docs.scs.community/standards/scs-0102-v1-image-metadata/#image-build-info
